### PR TITLE
Add codeowner file and update checklist

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @eiffel-community/eiffel-community-maintainers will be
+# requested for review when someone opens a pull request.
+
+* @eiffel-community/eiffel-community-maintainers

--- a/repo-checklist.md
+++ b/repo-checklist.md
@@ -28,3 +28,4 @@ After copying the contents of this repo into the new repo-to-be, follow the belo
    1. Give the team write access to the new repository.
 1. Create a maintainers' mailing list. There are no requirements on mailing list providers, but it needs to be invite only, readable by members only, but accept mails from non-members. [Google Groups](http://groups.google.com/) can easily set up such mailing lists.
 1. Update https://github.com/eiffel-community/community/blob/master/CONTACT.md with a new line for this repository.
+1. Update CODEOWNERS file with the correct maintainer list.


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/community/issues/7

### Description of the Change
Since we have decided that repositories should have code owner files for automatically adding reviewers etc. the repository-template must reflect this decision. 

### Alternate Designs

### Benefits
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Henning Roos  henning.roos@ericsson.com
