### PR TITLE
Update readme with general copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!---
-   Copyright 2018 Ericsson AB.
+   Copyright [yyyy] [name of copyright owner]
    For a full list of individual contributors, please see the commit history.
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Applicable Issues
#14 

### Description of the Change
Since the template repository is made for copying when creating new repositories we cannot have Ericsson in the copyright notice.

### Benefits
We do not get Ericsson as the copyright owner by mistake in new projects.

### Possible Drawbacks
None that the current solution does not already have.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Henning Roos henning.roos@ericsson.com
