### PR TITLE
Replace links to CONTACT.md with PROJECTS.md links

### DIFF
--- a/repo-checklist.md
+++ b/repo-checklist.md
@@ -28,5 +28,5 @@ After copying the contents of this repo into the new repo-to-be, follow the belo
    1. Give the team write access to the new repository.
 1. Create a maintainers' mailing list. There are no requirements on mailing list providers, but it needs to be invite only, readable by members only, but accept mails from non-members. [Google Groups](http://groups.google.com/) can easily set up such mailing lists.
    1. Add all [TC members](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) as owners in this mailing list.
-1. Update https://github.com/eiffel-community/community/blob/master/CONTACT.md with a new line for this repository.
+1. Update https://github.com/eiffel-community/community/blob/master/PROJECTS.md with a new line for this repository.
 1. Update CODEOWNERS file with the correct maintainer list.


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/community/issues/106

### Description of the Change
The contents of the community repo's CONTACT.md and PROJECTS.md were so similar that they were merged into a single file, PROJECTS.md. Adjusted all links accordingly.

### Alternate Designs
None.

### Benefits
No 404s when CONTACT.md is removed :-)

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
